### PR TITLE
ReLU layer instead of function

### DIFF
--- a/gcn_package/models/gcn.py
+++ b/gcn_package/models/gcn.py
@@ -10,38 +10,42 @@ class YuGCN(torch.nn.Module):
         super().__init__()
         self.edge_index = edge_index
         self.edge_weight = edge_weight
-        self.conv1 = tg.nn.ChebConv(in_channels=n_timepoints, out_channels=n_filters, K=2,bias=True)
-        self.conv2 = tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True)
-        self.conv3 = tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True)
-        self.conv4 = tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True)
-        self.conv5 = tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True)
-        self.conv6 = tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True)
-        self.fc1 = nn.Linear(n_filters * n_roi, 256)
-        self.fc2 = nn.Linear(256, 128)
-        self.fc3 = nn.Linear(128, n_classes)
-        self.dropout = nn.Dropout(0.5)
+
+        self.features = tg.nn.Sequential('x, edge_index, edge_weight', [
+            (tg.nn.ChebConv(in_channels=n_timepoints, out_channels=n_filters, K=2,bias=True),
+             'x, edge_index, edge_weight -> x'),
+            nn.ReLU(inplace=True),
+            (tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True),
+             'x, edge_index, edge_weight -> x'),
+            nn.ReLU(inplace=True),
+            (tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True),
+             'x, edge_index, edge_weight -> x'),
+            nn.ReLU(inplace=True),
+            (tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True),
+             'x, edge_index, edge_weight -> x'),
+            nn.ReLU(inplace=True),
+            (tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True),
+             'x, edge_index, edge_weight -> x'),
+            nn.ReLU(inplace=True),
+            (tg.nn.ChebConv(in_channels=n_filters, out_channels=n_filters, K=2, bias=True),
+             'x, edge_index, edge_weight -> x'),
+        ])
+        self.pool = tg.nn.global_mean_pool
+        self.classifier = nn.Sequential(
+            nn.Linear(n_filters * n_roi, 256),
+            nn.Dropout(0.5),
+            nn.Linear(256, 128),
+            nn.Dropout(0.5),
+            nn.Linear(128, n_classes)
+        )
 
     def forward(self, x):
+        batch_vector = torch.from_numpy(np.array(range(x.size(0)), dtype=int))
 
-        x = self.conv1(x, self.edge_index, self.edge_weight)
-        x = F.relu(x)
-        x = self.conv2(x, self.edge_index, self.edge_weight)
-        x = F.relu(x)
-        x = self.conv3(x, self.edge_index, self.edge_weight)
-        x = F.relu(x)
-        x = self.conv4(x, self.edge_index, self.edge_weight)
-        x = F.relu(x)
-        x = self.conv5(x, self.edge_index, self.edge_weight)
-        x = F.relu(x)
-        x = self.conv6(x, self.edge_index, self.edge_weight)
-        x = tg.nn.global_mean_pool(x, torch.from_numpy(np.array(range(x.size(0)), dtype=int)))
-
+        x = self.features(x, self.edge_index, self.edge_weight)
+        x = self.pool(x, batch_vector)
         x = torch.flatten(x, 1)
-        x = self.fc1(x)
-        x = self.dropout(x)
-        x = self.fc2(x)
-        x = self.dropout(x)
-        x = self.fc3(x)
+        x = self.classifier(x)
         return x
 
 class LoicGCN(torch.nn.Module):


### PR DESCRIPTION
Numerically, this performs the same way as the current version, but making the hook function registration implementation easier:

```
# switch the model to evaluation mode
gcn.eval()

# use a hook to remove negative gradient
def relu_hook_function(module, grad_in, grad_out):
    if isinstance(module, torch.nn.ReLU):
        return (torch.clamp(grad_in[0], min=0.0), )

for pos, module in gcn.features._modules.items():
    if isinstance(module, torch.nn.ReLU):
        print(gcn.named_modules())
        module.register_backward_hook(relu_hook_function)

```